### PR TITLE
iOS 18 Crash Issue Fixed

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "swift-collections",
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
-          "branch": null,
-          "revision": "48254824bb4248676bf7ce56014ff57b142b77eb",
-          "version": "1.0.2"
+          "branch": "main",
+          "revision": "11433b688df0e0b8c3deee56c30294ed63d929eb",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/yahoojapan/SwiftyXMLParser.git", from: "5.6.0"),
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-collections.git", branch: "main")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/EmojiPickerViewController/Controllers/EmojiPickerViewController.swift
+++ b/Sources/EmojiPickerViewController/Controllers/EmojiPickerViewController.swift
@@ -608,14 +608,25 @@ extension EmojiPickerViewController: UICollectionViewDelegateFlowLayout {
      This implementation is to adopt size category changes.
      */
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-
-        guard let header = diffableDataSource.collectionView(collectionView, viewForSupplementaryElementOfKind: UICollectionView.elementKindSectionHeader, at: IndexPath(row: 0, section: section)) as? LabelCollectionHeaderView else {
-            return CGSize(width: collectionView.bounds.width, height: 50) // Default size
-        }
-
-        let sizeForAdoptingTraitChanges = header.systemLayoutSizeFitting(.init(width: collectionView.bounds.width, height: UIView.layoutFittingExpandedSize.height), withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel)
-
-        return sizeForAdoptingTraitChanges
+        let temporaryHeaderView = LabelCollectionHeaderView(frame: CGRect(x: 0, y: 0, width: collectionView.bounds.width, height: 0))
+        
+        temporaryHeaderView.appearance = EmojiPickerConfiguration.HeaderAppearance(
+            font: UIFont.systemFont(ofSize: 16),
+            textColor: .label,
+            textAlignment: .center,
+            backgroundColor: .systemBackground,
+            labelPadding: UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16)
+        )
+        
+        temporaryHeaderView.headerLabel.text = " "
+        
+        let fittingSize = temporaryHeaderView.systemLayoutSizeFitting(
+            CGSize(width: collectionView.bounds.width, height: UIView.layoutFittingExpandedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        
+        return fittingSize
     }
 
     /*


### PR DESCRIPTION
The PR fixes an issue where a crash occurs when calculating header size in the 'collectionView(_:layout:referenceSizeForHeaderInSection:)' method by incorrectly referencing the header view using 'diffableDataSource.collectionView(_:viewForSupplementaryElementOfKind:at:)' in iOS 18.

![스크린샷 2024-10-05 오전 10 30 12](https://github.com/user-attachments/assets/210ceca9-cdf0-49b5-aef0-e26aa9215d0c)