### PR TITLE
use tagged version of swift collections

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/yahoojapan/SwiftyXMLParser.git", from: "5.6.0"),
-        .package(url: "https://github.com/apple/swift-collections.git", branch: "main")
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.4")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
The current code depends on the "unsafe" main branch of swift-collections. This won't work for projects that are using a safe tagged version of this library.