### PR TITLE
Fix typos across project

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -55,14 +55,14 @@ class ViewController: UIViewController {
         // configuration.headerAppearance.textAlignment = .center
 
         /*
-         Changing each cell appeanrance.
+         Changing each cell appearance.
          */
         // configuration.cellAppearance.size = .init(width: 30, height: 30)
 
         let emojiPicker = EmojiPickerViewController(configuration: configuration)
 
         /*
-         Receiveing events from the picker view controller.
+         Receiving events from the picker view controller.
          */
         emojiPicker.delegate = self
 
@@ -92,7 +92,7 @@ class ViewController: UIViewController {
         // EmojiContainer.main.load()
         
         /*
-         This is recommented implementation. In iPad, presents the picker as a popover, otherwise presents it as a sheet.
+         This is recommended implementation. In iPad, presents the picker as a popover, otherwise presents it as a sheet.
          */
         if traitCollection.userInterfaceIdiom == .pad {
 

--- a/LICENSE
+++ b/LICENSE
@@ -222,7 +222,7 @@ Original Licence URL: https://github.com/unicode-org/cldr/blob/main/unicode-lice
 
 ## Changes in This Source:
 
-- Renames file names in `annotationsDerived` to `xxx_derived.xml`, because files in `annotations` have same names and swift package don't allow existance of same name.
+- Renames file names in `annotationsDerived` to `xxx_derived.xml`, because files in `annotations` have same names and swift package doesn't allow existence of same name.
 
 ## Text
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A picker view controller for emoji.
 
 -   [x] [UTS#51 Specification](https://unicode.org/reports/tr51/)-compliant Emoji Picker(Not Tested Yet)
 -   [x] Segmented control for jumping an emoji section
--   [x] Seach bar and search results
+-   [x] Search bar and search results
 -   [x] Fully accessible
 -   [x] Dark mode
 -   [x] Recently used
@@ -74,11 +74,11 @@ You can get an `Emoji` object by accessing a singleton `EmojiContainer` instance
 ```swift
 let bouncingBall = EmojiContainer.main.entireEmojiSet["⛹🏿‍♀"]!
 print(bouncingBall)
-// Prints "character: ⛹🏿‍♀, status: minimallyQualified, group: People & Body, subgroup: person-sport, cldrOrder: 2360, annotation: ball | dark skin tone | woman | woman bouncing ball, textToSpeach: woman bouncing ball: dark skin tone"
+// Prints "character: ⛹🏿‍♀, status: minimallyQualified, group: People & Body, subgroup: person-sport, cldrOrder: 2360, annotation: ball | dark skin tone | woman | woman bouncing ball, textToSpeech: woman bouncing ball: dark skin tone"
 
 let grape = EmojiContainer.main.labeledEmojisForKeyboard[.foodDrink]![0]
 print(grape)
-// Prints "character: 🍇, status: fullyQualified, group: Food & Drink, subgroup: food-fruit, cldrOrder: 3323, annotation: fruit | grape | grapes, textToSpeach: grapes"
+// Prints "character: 🍇, status: fullyQualified, group: Food & Drink, subgroup: food-fruit, cldrOrder: 3323, annotation: fruit | grape | grapes, textToSpeech: grapes"
 ```
 
 See and run [Example](./Example/) for checking usages.

--- a/Sources/EmojiPickerViewController/Controllers/EmojiPickerViewController.swift
+++ b/Sources/EmojiPickerViewController/Controllers/EmojiPickerViewController.swift
@@ -347,7 +347,7 @@ open class EmojiPickerViewController: UIViewController {
                 cell.isAccessibilityElement = true
                 cell.accessibilityElements = []
                 cell.accessibilityTraits = .button
-                cell.accessibilityLabel = "\(emoji.textToSpeach), \(index)"
+                cell.accessibilityLabel = "\(emoji.textToSpeech), \(index)"
 
             } else {
 

--- a/Sources/EmojiPickerViewController/Models/Emoji.swift
+++ b/Sources/EmojiPickerViewController/Models/Emoji.swift
@@ -123,7 +123,7 @@ public class Emoji {
 
      - SeeAlso: [UITextInputMode.currentInputModeDidChangeNotification](https://developer.apple.com/documentation/uikit/uitextinputmode/1614517-currentinputmodedidchangenotific)
      */
-    internal(set) public var textToSpeach: String = ""
+    internal(set) public var textToSpeech: String = ""
 
     /**
      The skin-tone's variations of this emoji. The value is `empty` when the emoji is not emoji modifier base.
@@ -247,7 +247,7 @@ extension Emoji: CustomStringConvertible {
     public var description: String {
 
         """
-        <Emoji: character=\(character) status=\(status) cldrOrder=\(cldrOrder) group=\(group) subgroup=\(subgroup) annotation=\(annotation) textToSpeach=\(textToSpeach) orderedSkinToneEmojis=\(orderedSkinToneEmojis.map(\.character)) genericSkinToneEmoji=\(String(describing: genericSkinToneEmoji?.character)) minimallyQualifiedOrUnqualifiedVersions=\(minimallyQualifiedOrUnqualifiedVersions.map(\.character)) fullyQualifiedVersion=\(String(describing: fullyQualifiedVersion?.character))>
+        <Emoji: character=\(character) status=\(status) cldrOrder=\(cldrOrder) group=\(group) subgroup=\(subgroup) annotation=\(annotation) textToSpeech=\(textToSpeech) orderedSkinToneEmojis=\(orderedSkinToneEmojis.map(\.character)) genericSkinToneEmoji=\(String(describing: genericSkinToneEmoji?.character)) minimallyQualifiedOrUnqualifiedVersions=\(minimallyQualifiedOrUnqualifiedVersions.map(\.character)) fullyQualifiedVersion=\(String(describing: fullyQualifiedVersion?.character))>
         """
 
     }

--- a/Sources/EmojiPickerViewController/Models/EmojiContainer.swift
+++ b/Sources/EmojiPickerViewController/Models/EmojiContainer.swift
@@ -138,7 +138,7 @@ public class EmojiContainer: Loader {
     }
 
     /**
-     Returns emojis which contains the given keyword in `annotation` property. minimally-qualified emojis , unqualified emojis and emoji modifier sequences (skintoned emoji) are ignored from search targets.
+     Returns emojis which contain the given keyword in `annotation` property. Minimally-qualified emojis, unqualified emojis and emoji modifier sequences (skin-toned emoji) are ignored from search targets.
 
      - Precondition:
      This method should be called after an initial call of `load()`.
@@ -160,7 +160,7 @@ public class EmojiContainer: Loader {
     /**
      An async interface of `searchEmojisForKeyboard(from:)`.
 
-     Using this async interface is recommented for providing resut-set in picker or keyboard.
+     Using this async interface is recommended for providing result set in picker or keyboard.
      */
     public func searchEmojisForKeyboard(from keyboard: String) async -> [Emoji] {
         precondition(!entireEmojiSet.isEmpty && !labeledEmojisForKeyboard.isEmpty)

--- a/Sources/EmojiPickerViewController/Models/EmojiLocale.swift
+++ b/Sources/EmojiPickerViewController/Models/EmojiLocale.swift
@@ -27,7 +27,7 @@ import Foundation
 /**
  A locale for which loads the associated language specific files.
 
- An `EmojiContainer`instance reads `annotations/{localeID}.xml` and `annotationsDerived/{localeID}.xml` to fill the emoji's `annotation` and `textToSpeach` properties. This object specified the locale information for which file should be loaded.
+ An `EmojiContainer`instance reads `annotations/{localeID}.xml` and `annotationsDerived/{localeID}.xml` to fill the emoji's `annotation` and `textToSpeech` properties. This object specified the locale information for which file should be loaded.
 
  # Reading Difference
  Please see `Resources/CLDR/annotations/af` and `Resources/CLDR/annotations/af_SA`, you can see the first one describes many emojis and the second one describes very few emojis. The rule is that an annotation file which has the region resignator only describes regional differences between the base annotation file. The base annotation is `af` in this case.

--- a/Sources/EmojiPickerViewController/Models/Loader/EmojiAnnotationLoader.swift
+++ b/Sources/EmojiPickerViewController/Models/Loader/EmojiAnnotationLoader.swift
@@ -64,7 +64,7 @@ class EmojiAnnotationLoader: Loader {
 
      - Parameters:
        - emojiDictionary: The dictionary which the key is a `Character` and the value is a `Emoji`, for setting annotation and tts.
-       - emojiLocale:The locale which specifies the emoji locale information for the loading. `Emoji` annotation and textToSpeach are loaded following the given locale.
+       - emojiLocale:The locale which specifies the emoji locale information for the loading. `Emoji` annotation and textToSpeech are loaded following the given locale.
      */
     init(emojiDictionary: [Emoji.ID: Emoji], emojiLocale: EmojiLocale) {
 
@@ -98,8 +98,8 @@ class EmojiAnnotationLoader: Loader {
 
                 if annotation.attributes["type"] == "tts" {
 
-                    targetEmoji?.textToSpeach = annotation.text!
-                    targetEmoji?.fullyQualifiedVersion?.textToSpeach = annotation.text!
+                    targetEmoji?.textToSpeech = annotation.text!
+                    targetEmoji?.fullyQualifiedVersion?.textToSpeech = annotation.text!
 
                 } else {
 

--- a/Sources/EmojiPickerViewController/Models/Loader/EmojiLoader.swift
+++ b/Sources/EmojiPickerViewController/Models/Loader/EmojiLoader.swift
@@ -41,9 +41,9 @@ import Collections
  The excluded emoji from `labeledEmojisForKeyboard`are:
  - minimally-qualified emoji
  - unqualified emoji
- - emoji modifier sequences( because showing a generic-skin-toned emojis on a keyboard, and selecting a skin-tone valiation in the variations selector view, is a well-known experience in iOS and macOS)
+ - emoji modifier sequences( because showing a generic-skin-toned emoji on a keyboard, and selecting a skin-tone variation in the variations selector view, is a well-known experience in iOS and macOS)
 
- The values for `labeledEmojisForKeyboard` are stored in the order shown at  [Emoji Ordering](https://unicode.org/emoji/charts/emoji-ordering.html), and the type of `labeledEmojisForKeyboard` is an `OrderedDictionary` which can ensure the order of keys, so you can get complete labled and ordered emojis by enumerating the dictionay like this:
+ The values for `labeledEmojisForKeyboard` are stored in the order shown at  [Emoji Ordering](https://unicode.org/emoji/charts/emoji-ordering.html), and the type of `labeledEmojisForKeyboard` is an `OrderedDictionary` which can ensure the order of keys, so you can get complete labeled and ordered emojis by enumerating the dictionary like this:
 
  ```swift
  for (label, orderedEmojis) in labeledEmojisForKeyboard {
@@ -238,13 +238,13 @@ class EmojiLoader: Loader {
         var subgroup: Substring!
 
         /*
-         The local var are used for handling skin tones and minimally-qualified/unqualified versions.
+         The local variables are used for handling skin tones and minimally-qualified/unqualified versions.
 
          The most important expectation for combining variations is the orders of emojis in the `emoji-test.txt` file. The rules of the order are:
-         1. fully-qualified and non emoji modiifier sequence, which we name "variation base" is located at head. This is a separater of the variations of the emoji.
+         1. fully-qualified and non emoji modifier sequence, which we name "variation base" is located at head. This is a separator of the variations of the emoji.
          2. minimally-qualified or unqualified emojis are listed next of 1.
-         3. modifier sequences(skintoned emoji) are listed next of 2.
-         NOTE: modifier sequences may have its minimally-qualified or unqualified variations.
+         3. modifier sequences(skin-toned emoji) are listed next of 2.
+         NOTE: modifier sequences may have their minimally-qualified or unqualified variations.
 
          Ex)
          1F575 FE0F 200D 2642 FE0F                              ; fully-qualified     # 🕵️‍♂️ E4.0 man detective                             <VARIATION BASE>
@@ -265,10 +265,10 @@ class EmojiLoader: Loader {
          1F575 FE0F 200D 2640 FE0F                              ; fully-qualified     # 🕵️‍♀️ E4.0 woman detective                           <NEXT VARIATION BASE>
          */
 
-        // Variation base is fully-qualified and non emoji modiifier sequence.
+        // Variation base is fully-qualified and non emoji modifier sequence.
         var variationBaseEmoji:Emoji?
 
-        // FullyQualifiedEmoji is fully-qualified. It may be mofifier sequence.
+        // FullyQualifiedEmoji is fully-qualified. It may be modifier sequence.
         var fullyQualifiedEmoji: Emoji?
 
         var emojiOrder: Int = 0
@@ -327,7 +327,7 @@ class EmojiLoader: Loader {
 
                     } else {
 
-                        // Normally, a keyboard should present only variation base emoji, and present modifier sequences(skintoned) by long-pressing the key.
+                        // Normally, a keyboard should present only variation base emoji, and present modifier sequences(skin-toned) by long-pressing the key.
                         variationBaseEmoji = emoji
                         
                         if let label {

--- a/Sources/EmojiPickerViewController/Models/Loader/Loader.swift
+++ b/Sources/EmojiPickerViewController/Models/Loader/Loader.swift
@@ -31,7 +31,7 @@ import Foundation
 protocol Loader {
 
     /**
-     The bundle where the resouces are located.
+     The bundle where the resources are located.
      */
     var bundle: Bundle { get }
 
@@ -45,7 +45,7 @@ protocol Loader {
 extension Loader {
 
     /**
-     The bundle where the resouces are located. In swift package system, `.module` specifies the resource's bundle of the current module.
+     The bundle where the resources are located. In swift package system, `.module` specifies the resource's bundle of the current module.
      */
     var bundle: Bundle { .module }
 

--- a/Tests/EmojiPickerViewControllerTests/EmojiAnnotationDerivedLoaderTests.swift
+++ b/Tests/EmojiPickerViewControllerTests/EmojiAnnotationDerivedLoaderTests.swift
@@ -54,9 +54,9 @@ import XCTest
         loader.load()
 
         XCTAssertEqual(emojiDictionary["👋🏾"]?.annotation, "バイバイ | やや濃い肌色 | 手 | 手を振る", "Failed to load `ja` annotations.")
-        XCTAssertEqual(emojiDictionary["👋🏾"]?.textToSpeach, "手を振る: やや濃い肌色", "Failed to load `ja` textToSpeach.")
+        XCTAssertEqual(emojiDictionary["👋🏾"]?.textToSpeech, "手を振る: やや濃い肌色", "Failed to load `ja` textToSpeech.")
         XCTAssertEqual(emojiDictionary["🇲🇽"]?.annotation, "旗", "Failed to load `ja` annotations.")
-        XCTAssertEqual(emojiDictionary["🇲🇽"]?.textToSpeach, "旗: メキシコ", "Failed to load `ja` textToSpeach.")
+        XCTAssertEqual(emojiDictionary["🇲🇽"]?.textToSpeech, "旗: メキシコ", "Failed to load `ja` textToSpeech.")
 
     }
 
@@ -70,7 +70,7 @@ import XCTest
         loader.load()
 
         XCTAssertEqual(emojiDictionary["😀"]?.annotation, "")
-        XCTAssertEqual(emojiDictionary["😀"]?.textToSpeach, "")
+        XCTAssertEqual(emojiDictionary["😀"]?.textToSpeech, "")
 
     }
 

--- a/Tests/EmojiPickerViewControllerTests/EmojiAnnotationLoaderTests.swift
+++ b/Tests/EmojiPickerViewControllerTests/EmojiAnnotationLoaderTests.swift
@@ -53,9 +53,9 @@ import XCTest
         let loader = EmojiAnnotationLoader(emojiDictionary: emojiDictionary, emojiLocale: EmojiLocale(localeIdentifier: "ja")!)
         loader.load()
         XCTAssertEqual(emojiDictionary["😀"]?.annotation, "スマイル | にっこり | にっこり笑う | 笑う | 笑顔 | 顔", "Failed to load `ja` annotations.")
-        XCTAssertEqual(emojiDictionary["😀"]?.textToSpeach, "にっこり笑う", "Failed to load `ja` textToSpeach.")
+        XCTAssertEqual(emojiDictionary["😀"]?.textToSpeech, "にっこり笑う", "Failed to load `ja` textToSpeech.")
         XCTAssertEqual(emojiDictionary["💏"]?.annotation, "2人でキス | カップル | キス | ちゅっ | ハート", "Failed to load `ja` annotations.")
-        XCTAssertEqual(emojiDictionary["💏"]?.textToSpeach, "2人でキス", "Failed to load `ja` textToSpeach.")
+        XCTAssertEqual(emojiDictionary["💏"]?.textToSpeech, "2人でキス", "Failed to load `ja` textToSpeech.")
 
     }
 
@@ -69,7 +69,7 @@ import XCTest
         loader.load()
 
         XCTAssertEqual(emojiDictionary["👶🏾"]?.annotation, "")
-        XCTAssertEqual(emojiDictionary["👶🏾"]?.textToSpeach, "")
+        XCTAssertEqual(emojiDictionary["👶🏾"]?.textToSpeech, "")
 
     }
 

--- a/Tests/EmojiPickerViewControllerTests/EmojiContainerTests.swift
+++ b/Tests/EmojiPickerViewControllerTests/EmojiContainerTests.swift
@@ -61,21 +61,21 @@ import XCTest
         XCTAssertEqual(container.entireEmojiSet[flagWales]?.group, "Flags")
         XCTAssertEqual(container.entireEmojiSet[flagWales]?.subgroup, "subdivision-flag")
         XCTAssertEqual(container.entireEmojiSet[flagWales]?.annotation, "旗")
-        XCTAssertEqual(container.entireEmojiSet[flagWales]?.textToSpeach, "旗: ウェールズ")
+        XCTAssertEqual(container.entireEmojiSet[flagWales]?.textToSpeech, "旗: ウェールズ")
 
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.character, "🏴󠁧󠁢󠁷󠁬󠁳󠁿")
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.cldrOrder, emojiCountsListedInEmojiTest - 1) // the order starts from 0.
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.group, "Flags")
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.subgroup, "subdivision-flag")
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.annotation, "旗")
-        XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.textToSpeach, "旗: ウェールズ")
+        XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.textToSpeech, "旗: ウェールズ")
 
         // Test all fully-qualified emojis have annotation and tts.
         for (_, emojis) in container.labeledEmojisForKeyboard {
             for emoji in emojis {
                 XCTAssertNotEqual(emoji.annotation, "")
-                XCTAssertNotEqual(emoji.textToSpeach, "")
-                XCTAssertTrue(emoji.orderedSkinToneEmojis.allSatisfy({ $0.annotation != "" && $0.textToSpeach != "" }))
+                XCTAssertNotEqual(emoji.textToSpeech, "")
+                XCTAssertTrue(emoji.orderedSkinToneEmojis.allSatisfy({ $0.annotation != "" && $0.textToSpeech != "" }))
             }
         }
 
@@ -97,14 +97,14 @@ import XCTest
         XCTAssertEqual(container.labeledEmojisForKeyboard[.smileysPeople]?.first?.group, "Smileys & Emotion")
         XCTAssertEqual(container.labeledEmojisForKeyboard[.smileysPeople]?.first?.subgroup, "face-smiling")
         XCTAssertEqual(container.labeledEmojisForKeyboard[.smileysPeople]?.first?.annotation, "スマイル | にっこり | にっこり笑う | 笑う | 笑顔 | 顔")
-        XCTAssertEqual(container.labeledEmojisForKeyboard[.smileysPeople]?.first?.textToSpeach, "にっこり笑う")
+        XCTAssertEqual(container.labeledEmojisForKeyboard[.smileysPeople]?.first?.textToSpeech, "にっこり笑う")
 
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.character, "🏴󠁧󠁢󠁷󠁬󠁳󠁿")
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.cldrOrder, emojiCountsListedInEmojiTest - 1) // the order starts from 0.
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.group, "Flags")
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.subgroup, "subdivision-flag")
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.annotation, "旗")
-        XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.textToSpeach, "旗: ウェールズ")
+        XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.textToSpeech, "旗: ウェールズ")
 
         // Execute
         container.emojiLocale = EmojiLocale(localeIdentifier: "en")!
@@ -116,14 +116,14 @@ import XCTest
         XCTAssertEqual(container.labeledEmojisForKeyboard[.smileysPeople]?.first?.group, "Smileys & Emotion")
         XCTAssertEqual(container.labeledEmojisForKeyboard[.smileysPeople]?.first?.subgroup, "face-smiling")
         XCTAssertEqual(container.labeledEmojisForKeyboard[.smileysPeople]?.first?.annotation, "face | grin | grinning face")
-        XCTAssertEqual(container.labeledEmojisForKeyboard[.smileysPeople]?.first?.textToSpeach, "grinning face")
+        XCTAssertEqual(container.labeledEmojisForKeyboard[.smileysPeople]?.first?.textToSpeech, "grinning face")
 
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.character, "🏴󠁧󠁢󠁷󠁬󠁳󠁿")
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.cldrOrder, emojiCountsListedInEmojiTest - 1) // the order starts from 0.
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.group, "Flags")
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.subgroup, "subdivision-flag")
         XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.annotation, "flag")
-        XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.textToSpeach, "flag: Wales")
+        XCTAssertEqual(container.labeledEmojisForKeyboard[.flags]?.last?.textToSpeech, "flag: Wales")
 
     }
 

--- a/Tests/EmojiPickerViewControllerTests/EmojiLoaderTests.swift
+++ b/Tests/EmojiPickerViewControllerTests/EmojiLoaderTests.swift
@@ -160,12 +160,12 @@ let emojiCountsListedInEmojiTest = 4702
             XCTAssertNil(victoryHandEmoji.genericSkinToneEmoji)
             XCTAssertEqual(victoryHandEmoji.orderedSkinToneEmojis.count, 5)
 
-            for (index, skintonedEmoji) in victoryHandEmoji.orderedSkinToneEmojis.enumerated() {
-                XCTAssertEqual(skintonedEmoji.character, expectedSkintoneVariations[index])
-                XCTAssertNil(skintonedEmoji.fullyQualifiedVersion)
-                XCTAssertTrue(skintonedEmoji.minimallyQualifiedOrUnqualifiedVersions.isEmpty)
-                XCTAssertEqual(skintonedEmoji.genericSkinToneEmoji, victoryHandEmoji)
-                XCTAssertTrue(skintonedEmoji.orderedSkinToneEmojis.isEmpty)
+            for (index, skinTonedEmoji) in victoryHandEmoji.orderedSkinToneEmojis.enumerated() {
+                XCTAssertEqual(skinTonedEmoji.character, expectedSkintoneVariations[index])
+                XCTAssertNil(skinTonedEmoji.fullyQualifiedVersion)
+                XCTAssertTrue(skinTonedEmoji.minimallyQualifiedOrUnqualifiedVersions.isEmpty)
+                XCTAssertEqual(skinTonedEmoji.genericSkinToneEmoji, victoryHandEmoji)
+                XCTAssertTrue(skinTonedEmoji.orderedSkinToneEmojis.isEmpty)
             }
 
         }

--- a/Tests/EmojiPickerViewControllerTests/EmojiTests.swift
+++ b/Tests/EmojiPickerViewControllerTests/EmojiTests.swift
@@ -79,10 +79,10 @@ class EmojiTests: XCTestCase {
 
         let emoji = Emoji("⛹🏿‍♀", status: .minimallyQualified, cldrOrder: 2360, group: "People & Body", subgroup: "person-sport")
         emoji.annotation = "ball | dark skin tone | woman | woman bouncing ball"
-        emoji.textToSpeach = "woman bouncing ball: dark skin tone"
+        emoji.textToSpeech = "woman bouncing ball: dark skin tone"
 
         let expectedText = """
-        <Emoji: character=⛹🏿‍♀ status=minimallyQualified cldrOrder=2360 group=People & Body subgroup=person-sport annotation=ball | dark skin tone | woman | woman bouncing ball textToSpeach=woman bouncing ball: dark skin tone orderedSkinToneEmojis=[] genericSkinToneEmoji=nil minimallyQualifiedOrUnqualifiedVersions=[] fullyQualifiedVersion=nil>
+        <Emoji: character=⛹🏿‍♀ status=minimallyQualified cldrOrder=2360 group=People & Body subgroup=person-sport annotation=ball | dark skin tone | woman | woman bouncing ball textToSpeech=woman bouncing ball: dark skin tone orderedSkinToneEmojis=[] genericSkinToneEmoji=nil minimallyQualifiedOrUnqualifiedVersions=[] fullyQualifiedVersion=nil>
         """
         XCTAssertEqual(emoji.description, expectedText)
 


### PR DESCRIPTION
## Summary
- correct spelling mistakes in README and source comments
- update example documentation comments
- rename `textToSpeach` property to `textToSpeech`
- fix minor typos in LICENSE and tests

## Testing
- `swift test` *(fails: no such module 'UIKit')*